### PR TITLE
Fixing '--repo' long argument

### DIFF
--- a/mrepo
+++ b/mrepo
@@ -83,7 +83,7 @@ class Options:
 
         try:
             opts, args = getopt.getopt (args, 'c:d:fghnqr:t:uvx',
-                ('config=', 'dist=', 'dry-run', 'force', 'generate', 'help', 'quiet', 'repo',
+                ('config=', 'dist=', 'dry-run', 'force', 'generate', 'help', 'quiet', 'repo=',
                 'remount', 'type=', 'umount', 'unmount', 'update', 'verbose', 'version', 'extras'))
         except getopt.error, exc:
             print 'mrepo: %s, try mrepo -h for a list of all the options' % str(exc)


### PR DESCRIPTION
Found that '--repo' refused to take any arguments, but '-r' worked fine.  Simple python typo.
