### PR TITLE
Add fuse Requires

### DIFF
--- a/mrepo.spec
+++ b/mrepo.spec
@@ -21,6 +21,7 @@ BuildRequires: /usr/bin/python2
 Requires: createrepo
 Requires: python >= 2.0
 Requires: pyOpenSSL
+Requires: fuse
 Obsoletes: yam <= %{version}
 
 %description


### PR DESCRIPTION
Attempting to run with --remount without fuse results in an error due to
a missing `fusermount`.

Signed-off-by: Sol Jerome sol.jerome@gmail.com

```
# mrepo --remount 5Server
sh: line 0: exec: fusermount: not found
```
