### PR TITLE
Add FTP support to reposync:// scheme.

### DIFF
--- a/mrepo
+++ b/mrepo
@@ -130,7 +130,7 @@ class Options:
         if not self.types:
             self.types = ['file', 'fish', 'ftp', 'http', 'https', 'mc', 'rhn',
                           'rhns', 'rsync', 'sftp', 'mrepo', 'you', 'reposync', 'reposyncs',
-                          reposyncf']
+                          'reposyncf']
 
         for arg in args:
             self.dists = self.dists + arg.split(',')


### PR DESCRIPTION
This adds the ability for FTP yum repos. There are some in the
world that are only available via FTP, sadly. This introduces
a new scheme, reposyncf:// similar to the reposyncs:// scheme.
