### PR TITLE
mrepo: Remove temporary reposync config files before raising exceptions

### DIFF
--- a/mrepo
+++ b/mrepo
@@ -1541,11 +1541,12 @@ enabled=1
 
     ret = run("%s %s -t -c '%s' -r %s -p '%s'" % \
               (cf.cmd['reposync'], opts, reposync_conf_file, reponame, path))
-    if ret:
-        raise(mrepoMirrorException('Failed with return code: %s' % ret))
 
     # remove the temporary config
     os.remove(reposync_conf_file)
+
+    if ret:
+        raise(mrepoMirrorException('Failed with return code: %s' % ret))
 
 
 def hardlink(srcdir):


### PR DESCRIPTION
If a single file/fetch fails during a reposync, mrepo will raise an
exception over it (and continue) but will not cleanup the temporary
config.

Results in this:

```
$ ls -la /tmp/tmp* | tail
-rw------- 1 root root 133 Jun 29 23:15 /tmp/tmpzCRrbK
-rw------- 1 root root 133 Jun 26 22:45 /tmp/tmpzCdtxq
-rw------- 1 root root 133 Jul  6 04:15 /tmp/tmpzJ2rdp
-rw------- 1 root root 133 Jul  2 16:30 /tmp/tmpzKc_s5
-rw------- 1 root root 133 Jun 27 14:15 /tmp/tmpzW4E_h
-rw------- 1 root root 133 Jul  6 15:30 /tmp/tmpzhzBuJ
-rw------- 1 root root 133 Jun 27 07:45 /tmp/tmpziEzGo
-rw------- 1 root root 133 Jun 26 03:30 /tmp/tmpzkp3Ym
-rw------- 1 root root 133 Jun 26 19:30 /tmp/tmpztKB57
-rw------- 1 root root 133 Jul  5 12:15 /tmp/tmpztbK9i
$ ls -la /tmp/tmp* | wc -l
1039
$ sudo cat /tmp/tmpztbK9i
[EnterpriseLinux5-x86_64-percona]
name=EnterpriseLinux5-x86_64-percona
baseurl=http://repo.percona.com/centos/5/os/x86_64/
enabled=1
```
