### PR TITLE
mrepo.spec: Add fuse dependency

### DIFF
--- a/mrepo.spec
+++ b/mrepo.spec
@@ -19,6 +19,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 BuildRequires: /usr/bin/python2
 Requires: createrepo
+Requires: fuse
 Requires: python >= 2.0
 Requires: pyOpenSSL
 Obsoletes: yam <= %{version}


### PR DESCRIPTION
Without fuse installed, the --remount command will not work when it
requires unmounting an ISO.

  # mrepo --remount
  sh: line 0: exec: fusermount: not found

Signed-off-by: Sol Jerome sol.jerome@gmail.com
